### PR TITLE
bacon: enable mtp by default

### DIFF
--- a/bacon.mk
+++ b/bacon.mk
@@ -262,6 +262,9 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/thermal-engine.conf:system/etc/thermal-engine-8974.conf
 
 # USB
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
+    persist.sys.usb.config=mtp
+
 PRODUCT_PACKAGES += \
     com.android.future.usb.accessory
 


### PR DESCRIPTION
Lets people choose if they want to enable debugging via Developer Mode or with the switcher, not by default.
